### PR TITLE
Run build jobs asyncronously

### DIFF
--- a/src/main/java/buildtools/BuildJob.java
+++ b/src/main/java/buildtools/BuildJob.java
@@ -12,6 +12,7 @@ public class BuildJob {
   public static String BUILD_CONFIG_FILE_NAME = ".dd.yml";
   public static void run(String jobID, String cloneURL, String branchRef) {
     // TODO: update database that status is "started"
+    System.out.println("Running build job with id " + jobID);
 
     Git git = null;
     try {
@@ -49,6 +50,8 @@ public class BuildJob {
     } else {
       BuildJob.fail(jobID, "Failed to find a build file.");
     }
+
+    System.out.println("Finished build job with id " + jobID);
   }
 
   public static void fail(String jobID, String log) {

--- a/src/main/java/resources/Resource.java
+++ b/src/main/java/resources/Resource.java
@@ -6,12 +6,16 @@ import buildtools.BuildJob;
 import org.json.JSONObject;
 
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
 @Path("ci")
 public class Resource {
+
+    ExecutorService jobsQueue = Executors.newFixedThreadPool(10);
     // EXAMPLE GET REQUEST HANDLER
     // A list of of builds is sent by returning List<Build> instead.
     // TODO
@@ -51,7 +55,9 @@ public class Resource {
         String branchRef = json.getString("ref");
         String cloneUrl = repository.getString("clone_url");
 
-        BuildJob.run(jobID, cloneUrl, branchRef);
+        // Run build jobs asynchronously
+        Runnable job = () -> BuildJob.run(jobID, cloneUrl, branchRef);
+        jobsQueue.execute(job);
 
         return Response.status(200).build();
     }


### PR DESCRIPTION
Se issue #37 .

Github shouldn't have to wait for build jobs to finish to get a response on a webhook. We solve this by using an Executor service.