### PR TITLE
Migrate build log schema

### DIFF
--- a/src/main/java/buildtools/Build.java
+++ b/src/main/java/buildtools/Build.java
@@ -1,5 +1,8 @@
 package buildtools;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Build {
     public enum Result {
         pending,
@@ -12,9 +15,9 @@ public class Build {
     private Result status;
     private String commitSha;
     private String url;
-    private String log;
+    private List<ArrayList<String>> log;
 
-    public Build(String jobID, Result status, String commitSha, String url, String log) {
+    public Build(String jobID, Result status, String commitSha, String url, List<ArrayList<String>> log) {
         this.jobID = jobID;
         this.status = status;
         this.commitSha = commitSha;
@@ -38,7 +41,7 @@ public class Build {
         return url;
     }
 
-    public String getLog() {
+    public List<ArrayList<String>> getLog() {
         return log;
     }
 
@@ -58,7 +61,7 @@ public class Build {
         this.url = url;
     }
 
-    public void setLog(String log) {
+    public void setLog(List<ArrayList<String>> log) {
         this.log = log;
     }
 

--- a/src/main/java/buildtools/BuildJob.java
+++ b/src/main/java/buildtools/BuildJob.java
@@ -3,6 +3,7 @@ package buildtools;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -14,17 +15,30 @@ public class BuildJob {
   public static String BUILD_CONFIG_FILE_NAME = ".dd.yml";
   private static Storage storage = new Storage();
   public static void run(String jobID, String cloneURL, String branchRef) {
+    List<ArrayList<String>> log = new ArrayList<ArrayList<String>>();
+    ArrayList<String> logEntry = new ArrayList<String>();
+    logEntry.add("Running build job with id " + jobID);
+    log.add(logEntry);
+
+
     System.out.println("Running build job with id " + jobID);
-    Build pendingBuild = new Build(jobID, Build.Result.pending, "", "", "");
+    Build pendingBuild = new Build(jobID, Build.Result.pending, "", "", log);
 
     try {
       BuildJob.storage.post(pendingBuild);
 
     } catch (IOException e) {
       e.printStackTrace();
-      BuildJob.fail(jobID, "Internal issue. Contact support.");
+      logEntry.clear();
+      logEntry.add("Internal issue. Contact support.");
+      log.add(logEntry);
+      BuildJob.fail(jobID, log);
       return;
     }
+
+    logEntry.clear();
+    logEntry.add("Cloning repository.");
+    log.add(logEntry);
 
 
     Git git = null;
@@ -37,7 +51,10 @@ public class BuildJob {
 
     } catch (GitAPIException e) {
       e.printStackTrace();
-      BuildJob.fail(jobID, "Failed to clone repository " + cloneURL);
+      logEntry.clear();
+      logEntry.add("Failed to clone repository " + cloneURL);
+      log.add(logEntry);
+      BuildJob.fail(jobID, log);
       return;
     }
 
@@ -60,19 +77,29 @@ public class BuildJob {
           System.out.println(ln);
         }
       }
-      BuildJob.success(jobID, "Found build file.");
+
+      logEntry.clear();
+      logEntry.add("Found build file.");
+      log.add(logEntry);
+
+      BuildJob.success(jobID, log);
     } else {
-      BuildJob.fail(jobID, "Failed to find a build file.");
+
+      logEntry.clear();
+      logEntry.add("Failed to find a build file.");
+      log.add(logEntry);
+
+      BuildJob.fail(jobID, log);
     }
 
     System.out.println("Finished build job with id " + jobID);
   }
 
-  public static void fail(String jobID, String log) {
+  public static void fail(String jobID, List<ArrayList<String>> log) {
     // TODO:
     // Call notification engine
 
-    Build failedBuild = new Build(jobID, Build.Result.failure, "", "", "");
+    Build failedBuild = new Build(jobID, Build.Result.failure, "", "", log);
     try {
       BuildJob.storage.post(failedBuild);
 
@@ -86,11 +113,11 @@ public class BuildJob {
 
   }
 
-  public static void success(String jobID, String log) {
+  public static void success(String jobID, List<ArrayList<String>> log) {
     // TODO:
     // Call notification engine
 
-    Build succeededBuild = new Build(jobID, Build.Result.success, "", "", "");
+    Build succeededBuild = new Build(jobID, Build.Result.success, "", "", log);
     try {
       BuildJob.storage.post(succeededBuild);
 

--- a/src/main/java/buildtools/BuildJob.java
+++ b/src/main/java/buildtools/BuildJob.java
@@ -81,6 +81,7 @@ public class BuildJob {
       logEntry.clear();
       logEntry.add("Found build file.");
       log.add(logEntry);
+      log.addAll(commands);
 
       BuildJob.success(jobID, log);
     } else {

--- a/src/main/java/buildtools/BuildJob.java
+++ b/src/main/java/buildtools/BuildJob.java
@@ -18,7 +18,7 @@ public class BuildJob {
     List<ArrayList<String>> log = new ArrayList<ArrayList<String>>();
     ArrayList<String> logEntry = new ArrayList<String>();
     logEntry.add("Running build job with id " + jobID);
-    log.add(logEntry);
+    log.add(new ArrayList(logEntry));
 
 
     System.out.println("Running build job with id " + jobID);
@@ -38,7 +38,7 @@ public class BuildJob {
 
     logEntry.clear();
     logEntry.add("Cloning repository.");
-    log.add(logEntry);
+    log.add(new ArrayList(logEntry));
 
 
     Git git = null;
@@ -53,7 +53,7 @@ public class BuildJob {
       e.printStackTrace();
       logEntry.clear();
       logEntry.add("Failed to clone repository " + cloneURL);
-      log.add(logEntry);
+      log.add(new ArrayList(logEntry));
       BuildJob.fail(jobID, log);
       return;
     }
@@ -80,7 +80,7 @@ public class BuildJob {
 
       logEntry.clear();
       logEntry.add("Found build file.");
-      log.add(logEntry);
+      log.add(new ArrayList(logEntry));
       log.addAll(commands);
 
       BuildJob.success(jobID, log);
@@ -88,7 +88,7 @@ public class BuildJob {
 
       logEntry.clear();
       logEntry.add("Failed to find a build file.");
-      log.add(logEntry);
+      log.add(new ArrayList(logEntry));
 
       BuildJob.fail(jobID, log);
     }

--- a/src/main/java/resources/Resource.java
+++ b/src/main/java/resources/Resource.java
@@ -4,9 +4,11 @@ import buildtools.Build;
 import buildtools.BuildJob;
 
 import org.json.JSONObject;
+import org.json.JSONArray;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,7 +30,19 @@ public class Resource {
         String jobID = key;
         String commitSha = o.getString("commitSha");
         String url = o.getString("url");
-        String log = o.getString("log");
+        JSONArray allLogsJson = o.getJSONArray("log");
+
+        List<ArrayList<String>> log = new ArrayList<ArrayList<String>>();
+
+        for (int i = 0; i < allLogsJson.length(); i++) {
+            JSONArray logCommandJSON = allLogsJson.getJSONArray(i);
+            ArrayList<String> logCommand = new ArrayList<String>();
+
+            for (int j = 0; j < logCommandJSON.length(); j++) {
+                logCommand.add(logCommandJSON.getString(j));
+            }
+            log.add(logCommand);
+        }
 
         // fix status
         String tempStatus = o.getString("status");


### PR DESCRIPTION
Resolves issue #42.

Instead of a String build log we represent it as an array of arrays. Each outer array represent a group of log lines. Each inner array represent the lines.