### PR TITLE
Update ContinuousIntegrationServer.java, port number read from args[]

### DIFF
--- a/src/main/java/server/ContinuousIntegrationServer.java
+++ b/src/main/java/server/ContinuousIntegrationServer.java
@@ -25,8 +25,13 @@ public class ContinuousIntegrationServer {
 
     public static void main(String[] args) {
 
-        Server server = new Server(8018);
-
+        Server server;
+        try {
+            server = new Server(Integer.parseInt(args[0]));
+        } catch (Exception e) {
+            System.err.println("Error reading port number: ./gradlew args='<port number>'");
+            return;
+        }
         ServletContextHandler servletContextHandler = new ServletContextHandler(NO_SESSIONS);
 
         servletContextHandler.setContextPath("/");


### PR DESCRIPTION
Port number is now read from the command line arguments of the main function in ContinuousIntegrationServer.java. See issue #58.